### PR TITLE
gifエクスポートとwindowへの描画で共通のレンダリングコードを使う仕組みを作る

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3424,6 +3424,7 @@ dependencies = [
  "rect-renderer",
  "rotate_cube_basic",
  "text-renderer",
+ "with_gif",
 ]
 
 [[package]]
@@ -3455,6 +3456,8 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cgmath",
+ "futures-intrusive",
+ "gif",
  "pollster",
  "serde",
  "serde_json",
@@ -3791,6 +3794,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "with_gif"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cgmath",
+ "enum-rotate",
+ "env_logger",
+ "pollster",
+ "rand",
+ "wgpu 22.1.0",
+ "wgpu_helper",
+ "winit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "cube_blinn_phong",
  "hello-glyphon",
  "life-game",
+ "pollster",
  "rect-renderer",
  "rotate_cube_basic",
  "text-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ life-game         = { path = "./tutorial/life-game" }
 hello-glyphon     = { path = "./tutorial/hello-glyphon" }
 rect-renderer     = { path = "./prototype/rect-renderer" }
 text-renderer     = { path = "./prototype/text-renderer" }
+with_gif          = { path = "./prototype/with_gif" }
 cube_blinn_phong  = { path = "./practice/cube_blinn_phong" }
 rotate_cube_basic = { path = "./practice/rotate_cube_basic" }
 
@@ -24,6 +25,7 @@ members = [
   "lib/wgpu_helper",
   "prototype/rect-renderer",
   "prototype/text-renderer",
+  "prototype/with_gif",
   "tutorial/ch01-window",
   "tutorial/ch02-surface",
   "tutorial/ch03-pipeline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ text-renderer     = { path = "./prototype/text-renderer" }
 with_gif          = { path = "./prototype/with_gif" }
 cube_blinn_phong  = { path = "./practice/cube_blinn_phong" }
 rotate_cube_basic = { path = "./practice/rotate_cube_basic" }
+pollster          = "0.3.0"
 
 [workspace]
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ cargo run -- practice/cube_blinn_phong 4
 ```bash
 cargo run -- practice/rotate_cube_basic
 ```
+
+```bash
+cargo run -- prototype/with_gif
+```
+
+```bash
+cargo run -- export/with_gif
+```

--- a/lib/wgpu_helper/Cargo.toml
+++ b/lib/wgpu_helper/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow     = "1.0.89"
-bytemuck   = "1.18.0"
-cgmath     = "0.18.0"
-pollster   = "0.3.0"
-serde      = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
-wgpu       = "22.1.0"
-winit      = "0.30.5"
+anyhow            = "1.0.89"
+bytemuck          = "1.18.0"
+cgmath            = "0.18.0"
+futures-intrusive = "0.5.0"
+gif               = "0.13.1"
+pollster          = "0.3.0"
+serde             = { version = "1.0.210", features = ["derive"] }
+serde_json        = "1.0.128"
+wgpu              = "22.1.0"
+winit             = "0.30.5"

--- a/lib/wgpu_helper/src/context.rs
+++ b/lib/wgpu_helper/src/context.rs
@@ -1,0 +1,322 @@
+use std::sync::Arc;
+
+use winit::{dpi::PhysicalSize, window::Window};
+
+#[derive(Debug)]
+pub struct WgpuContext<'a> {
+  pub instance: wgpu::Instance,
+  pub adapter: wgpu::Adapter,
+  pub device: wgpu::Device,
+  pub queue: wgpu::Queue,
+  pub surface: Option<wgpu::Surface<'a>>,
+  pub config: Option<wgpu::SurfaceConfiguration>,
+  pub size: winit::dpi::PhysicalSize<u32>,
+  pub format: wgpu::TextureFormat,
+  pub sample_count: u32,
+}
+
+impl<'a> WgpuContext<'a> {
+  pub async fn new(
+    window: Arc<Window>,
+    sample_count: u32,
+    limits: Option<wgpu::Limits>,
+  ) -> Self {
+    let limits_device = limits.unwrap_or(wgpu::Limits::default());
+
+    let size = window.inner_size();
+    let instance = wgpu::Instance::default();
+    let surface = instance.create_surface(window).unwrap();
+
+    let adapter = instance
+      .request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::default(),
+        compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
+      })
+      .await
+      .expect("Failed to find an appropriate adapter");
+
+    let (device, queue) = adapter
+      .request_device(
+        &wgpu::DeviceDescriptor {
+          label: None,
+          required_features: wgpu::Features::default()
+            | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+          required_limits: limits_device,
+          ..Default::default()
+        },
+        None,
+      )
+      .await
+      .expect("Failed to create device");
+
+    let surface_caps = surface.get_capabilities(&adapter);
+    let format = surface_caps.formats[0];
+
+    let config = wgpu::SurfaceConfiguration {
+      usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+      format,
+      width: size.width,
+      height: size.height,
+      present_mode: wgpu::PresentMode::Fifo,
+      alpha_mode: surface_caps.alpha_modes[0],
+      view_formats: vec![],
+      desired_maximum_frame_latency: 2,
+    };
+    surface.configure(&device, &config);
+
+    Self {
+      instance,
+      surface: Some(surface),
+      adapter,
+      device,
+      queue,
+      config: Some(config),
+      format,
+      size,
+      sample_count,
+    }
+  }
+
+  pub async fn new_without_surface(
+    width: u32,
+    height: u32,
+    format: wgpu::TextureFormat,
+    sample_count: u32,
+  ) -> Self {
+    let size = PhysicalSize::new(width, height);
+
+    let instance = wgpu::Instance::default();
+
+    let adapter = instance
+      .request_adapter(&wgpu::RequestAdapterOptions::default())
+      .await
+      .unwrap();
+
+    let (device, queue) = adapter
+      .request_device(&wgpu::DeviceDescriptor::default(), None)
+      .await
+      .unwrap();
+
+    Self {
+      instance,
+      surface: None,
+      adapter,
+      device,
+      queue,
+      config: None,
+      size,
+      format,
+      sample_count,
+    }
+  }
+}
+
+pub struct RenderSet<'a> {
+  pub shader: Option<&'a wgpu::ShaderModule>,
+  pub vs_shader: Option<&'a wgpu::ShaderModule>,
+  pub fs_shader: Option<&'a wgpu::ShaderModule>,
+  pub vertex_buffer_layout: &'a [wgpu::VertexBufferLayout<'a>],
+  pub pipeline_layout: Option<&'a wgpu::PipelineLayout>,
+  pub topology: wgpu::PrimitiveTopology,
+  pub strip_index_format: Option<wgpu::IndexFormat>,
+  pub cull_mode: Option<wgpu::Face>,
+  pub is_depth_stencil: bool,
+  pub vs_entry: &'a str,
+  pub fs_entry: &'a str,
+}
+
+impl<'a> Default for RenderSet<'a> {
+  fn default() -> Self {
+    Self {
+      shader: None,
+      vs_shader: None,
+      fs_shader: None,
+      vertex_buffer_layout: &[],
+      pipeline_layout: None,
+      topology: wgpu::PrimitiveTopology::TriangleList,
+      strip_index_format: None,
+      cull_mode: None,
+      is_depth_stencil: true,
+      vs_entry: "vs_main",
+      fs_entry: "fs_main",
+    }
+  }
+}
+
+impl RenderSet<'_> {
+  pub fn new(&mut self, init: &WgpuContext) -> wgpu::RenderPipeline {
+    if self.shader.is_some() {
+      self.vs_shader = self.shader;
+      self.fs_shader = self.shader;
+    }
+
+    let depth_stencil = if self.is_depth_stencil {
+      Some(wgpu::DepthStencilState {
+        format: wgpu::TextureFormat::Depth24Plus,
+        depth_write_enabled: true,
+        depth_compare: wgpu::CompareFunction::LessEqual,
+        stencil: wgpu::StencilState::default(),
+        bias: wgpu::DepthBiasState::default(),
+      })
+    } else {
+      None
+    };
+
+    init.device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+      label: Some("Render Pipeline"),
+      layout: self.pipeline_layout,
+      vertex: wgpu::VertexState {
+        module: &self.vs_shader.unwrap(),
+        entry_point: &self.vs_entry,
+        buffers: &self.vertex_buffer_layout,
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+      },
+      fragment: Some(wgpu::FragmentState {
+        module: &self.fs_shader.unwrap(),
+        entry_point: &self.fs_entry,
+        targets: &[Some(init.format.into())],
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+      }),
+      primitive: wgpu::PrimitiveState {
+        topology: self.topology,
+        strip_index_format: self.strip_index_format,
+        ..Default::default()
+      },
+      depth_stencil,
+      multisample: wgpu::MultisampleState {
+        count: init.sample_count,
+        ..Default::default()
+      },
+      multiview: None,
+      cache: None,
+    })
+  }
+}
+
+fn create_uniform_bind_group_layout(
+  device: &wgpu::Device,
+  shader_stages: Vec<wgpu::ShaderStages>,
+) -> wgpu::BindGroupLayout {
+  let entries = shader_stages
+    .iter()
+    .enumerate()
+    .map(|(i, stage)| wgpu::BindGroupLayoutEntry {
+      binding: i as u32,
+      visibility: *stage,
+      ty: wgpu::BindingType::Buffer {
+        ty: wgpu::BufferBindingType::Uniform,
+        has_dynamic_offset: false,
+        min_binding_size: None,
+      },
+      count: None,
+    })
+    .collect::<Vec<_>>();
+
+  device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+    label: Some("Uniform Bind Group Layout"),
+    entries: entries.as_slice(),
+  })
+}
+
+pub fn create_uniform_bind_group(
+  device: &wgpu::Device,
+  shader_stages: Vec<wgpu::ShaderStages>,
+  resources: &[wgpu::BindingResource],
+) -> (wgpu::BindGroupLayout, wgpu::BindGroup) {
+  let entries = resources
+    .iter()
+    .enumerate()
+    .map(|(i, resource)| wgpu::BindGroupEntry {
+      binding: i as u32,
+      resource: resource.clone(),
+    })
+    .collect::<Vec<_>>();
+
+  let layout = create_uniform_bind_group_layout(device, shader_stages);
+  let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+    label: Some("Uniform Bind Group"),
+    layout: &layout,
+    entries: &entries,
+  });
+
+  (layout, bind_group)
+}
+
+pub fn create_color_attachment(
+  texture_view: &wgpu::TextureView,
+) -> wgpu::RenderPassColorAttachment {
+  wgpu::RenderPassColorAttachment {
+    view: texture_view,
+    resolve_target: None,
+    ops: wgpu::Operations {
+      load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+      store: wgpu::StoreOp::Store,
+    },
+  }
+}
+
+pub fn create_msaa_texture_view(init: &WgpuContext) -> wgpu::TextureView {
+  let msaa_texture = init.device.create_texture(&wgpu::TextureDescriptor {
+    label: None,
+    size: wgpu::Extent3d {
+      width: init.size.width,
+      height: init.size.height,
+      depth_or_array_layers: 1,
+    },
+    mip_level_count: 1,
+    sample_count: init.sample_count,
+    dimension: wgpu::TextureDimension::D2,
+    format: init.format,
+    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+    view_formats: &[],
+  });
+
+  msaa_texture.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+pub fn create_msaa_color_attachment<'a>(
+  texture_view: &'a wgpu::TextureView,
+  msaa_view: &'a wgpu::TextureView,
+) -> wgpu::RenderPassColorAttachment<'a> {
+  wgpu::RenderPassColorAttachment {
+    view: msaa_view,
+    resolve_target: Some(texture_view),
+    ops: wgpu::Operations {
+      load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+      store: wgpu::StoreOp::Store,
+    },
+  }
+}
+
+pub fn create_depth_view(init: &WgpuContext) -> wgpu::TextureView {
+  let depth_texture = init.device.create_texture(&wgpu::TextureDescriptor {
+    label: None,
+    size: wgpu::Extent3d {
+      width: init.size.width,
+      height: init.size.height,
+      depth_or_array_layers: 1,
+    },
+    mip_level_count: 1,
+    sample_count: init.sample_count,
+    dimension: wgpu::TextureDimension::D2,
+    format: wgpu::TextureFormat::Depth24Plus,
+    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+    view_formats: &[],
+  });
+
+  depth_texture.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+pub fn create_depth_stencil_attachment(
+  depth_view: &wgpu::TextureView,
+) -> wgpu::RenderPassDepthStencilAttachment {
+  wgpu::RenderPassDepthStencilAttachment {
+    view: depth_view,
+    depth_ops: Some(wgpu::Operations {
+      load: wgpu::LoadOp::Clear(1.0),
+      store: wgpu::StoreOp::Discard,
+    }),
+    stencil_ops: None,
+  }
+}

--- a/lib/wgpu_helper/src/framework/mod.rs
+++ b/lib/wgpu_helper/src/framework/mod.rs
@@ -1,1 +1,2 @@
 pub mod v1;
+pub mod with_gif;

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -368,6 +368,7 @@ impl<'a, R: Render<'a>> ApplicationHandler for App<'a, R> {
           Ok(submit) => {
             submit(&ctx.queue);
           }
+          // TODO: wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdatedの場合はresizeする
           //Err(wgpu::SurfaceError::Lost) => {
           //  renderer.resize(ctx, renderer.get_size(&ctx))
           //}

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -121,8 +121,6 @@ where
       dimension: wgpu::TextureDimension::D2,
       // TODO: self.ctx.formatを使うように変更
       format: wgpu::TextureFormat::Rgba8UnormSrgb,
-      // TextureUsages::RENDER_ATTACHMENTを使って、wgpuがテクスチャにレンダリングできるようにする
-      // TextureUsages::COPY_SRCはテクスチャからデータを取り出してファイルに保存できるようにするため
       usage: wgpu::TextureUsages::COPY_SRC
         | wgpu::TextureUsages::RENDER_ATTACHMENT,
       label: None,

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -47,6 +47,8 @@ pub trait Render<'a> {
   ) -> Result<impl FnOnce(&wgpu::Queue) -> (), wgpu::SurfaceError>;
 }
 
+// TODO: Appと同様の型パラメータ構成にできないか検討
+// TODO: GifでもMSAAに対応できないか実験
 pub struct Gif<'a, M, S, R>
 where
   R: Render<'a, DrawData = M, InitialState = S>,
@@ -120,6 +122,7 @@ where
       mip_level_count: 1,
       sample_count: 1,
       dimension: wgpu::TextureDimension::D2,
+      // TODO: self.ctx.formatを使うように変更
       format: wgpu::TextureFormat::Rgba8UnormSrgb,
       // TextureUsages::RENDER_ATTACHMENTを使って、wgpuがテクスチャにレンダリングできるようにする
       // TextureUsages::COPY_SRCはテクスチャからデータを取り出してファイルに保存できるようにするため
@@ -390,6 +393,11 @@ impl<'a, R: Render<'a>> ApplicationHandler for App<'a, R> {
     }
   }
 
+  // TODO: 更新間隔を指定できるようにする
+  // - need_redrawフラグを追加
+  // - 引数にupdate_interval: Option<Duration>を追加
+  // - update_intervalがSomeの場合、set_control_flowによる待機処理を入れる
+  // 参考: tutorial/life-game/src/app.rs
   fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
     let binding = self.window();
     let window = match &binding {

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -56,7 +56,6 @@ where
   renderer: R,
   size: u32,
   ctx: WgpuContext<'a>,
-  _phantom_data: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a, M, S, R> Gif<'a, M, S, R>
@@ -78,7 +77,6 @@ where
       renderer,
       size,
       ctx,
-      _phantom_data: std::marker::PhantomData,
     }
   }
 

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -45,7 +45,6 @@ pub trait Render<'a> {
     sample_count: Option<u32>,
     before_submit_hook: impl FnOnce(&mut wgpu::CommandEncoder) -> (),
   ) -> Result<impl FnOnce(&wgpu::Queue) -> (), wgpu::SurfaceError>;
-  // fn submit(&self, queue: &wgpu::Queue, output: DrawOutput);
 }
 
 pub struct Gif<'a, M, S, R>

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -1,0 +1,399 @@
+use std::{future::Future, mem, sync::Arc, time};
+
+use anyhow::Result;
+use winit::{
+  application::ApplicationHandler,
+  dpi::PhysicalSize,
+  event::{ElementState, KeyEvent, WindowEvent},
+  event_loop::{ActiveEventLoop, EventLoop},
+  keyboard::{KeyCode, PhysicalKey},
+  window::{Window, WindowId},
+};
+
+use crate::wgpu_simplified::WgpuContext;
+
+pub struct DrawOutput<'a> {
+  pub surface_texture: Option<wgpu::SurfaceTexture>,
+  pub encoder: &'a wgpu::CommandEncoder,
+}
+
+pub enum RenderTarget<'a> {
+  Surface(&'a wgpu::Surface<'a>),
+  Texture(&'a wgpu::Texture),
+}
+
+#[allow(opaque_hidden_inferred_bound)]
+pub trait Render<'a> {
+  type DrawData;
+  type InitialState;
+
+  fn new(
+    ctx: Option<&WgpuContext<'a>>,
+    draw_data: &Self::DrawData,
+    initial_state: &Self::InitialState,
+  ) -> impl Future<Output = Self>;
+  fn get_size(&self, ctx: &WgpuContext) -> PhysicalSize<u32> {
+    ctx.size
+  }
+  fn resize(&mut self, ctx: &mut WgpuContext, size: PhysicalSize<u32>);
+  fn process_event(&mut self, event: &WindowEvent) -> bool;
+  fn update(&mut self, ctx: &WgpuContext, dt: time::Duration);
+  fn draw(
+    &mut self,
+    encoder: &wgpu::CommandEncoder,
+    target: RenderTarget,
+    sample_count: Option<u32>,
+  ) -> Result<impl FnOnce(&wgpu::Queue) -> (), wgpu::SurfaceError>;
+  fn submit(&self, queue: &wgpu::Queue, output: DrawOutput);
+}
+
+pub struct Gif<'a, M, S, R>
+where
+  R: Render<'a, DrawData = M, InitialState = S>,
+{
+  renderer: R,
+  device: wgpu::Device,
+  queue: wgpu::Queue,
+  _phantom_data: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, M, S, R> Gif<'a, M, S, R>
+where
+  R: Render<'a, DrawData = M, InitialState = S>,
+{
+  pub async fn new(draw_data: M, initial_state: S) -> Self {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+      backends: wgpu::Backends::all(),
+      ..Default::default()
+    });
+
+    let adapter = instance
+      .request_adapter(&wgpu::RequestAdapterOptions::default())
+      .await
+      .unwrap();
+
+    let (device, queue) = adapter
+      .request_device(&wgpu::DeviceDescriptor::default(), None)
+      .await
+      .unwrap();
+
+    let renderer = R::new(None, &draw_data, &initial_state).await;
+
+    Self {
+      renderer,
+      device,
+      queue,
+      _phantom_data: std::marker::PhantomData,
+    }
+  }
+
+  pub fn build_renderer(
+    draw_data: M,
+    initial_state: S,
+  ) -> impl Future<Output = R> {
+    async move { R::new(None, &draw_data, &initial_state).await }
+  }
+
+  fn save_gif(
+    &self,
+    file_path: &str,
+    frames: &mut Vec<Vec<u8>>,
+    speed: i32,
+    size: u16,
+  ) -> anyhow::Result<()> {
+    use gif::{Encoder, Frame, Repeat};
+
+    let mut image = std::fs::File::create(file_path)?;
+    let mut encoder = Encoder::new(&mut image, size, size, &[])?;
+    encoder.set_repeat(Repeat::Infinite)?;
+
+    for mut frame in frames {
+      encoder
+        .write_frame(&Frame::from_rgba_speed(size, size, &mut frame, speed))?;
+    }
+
+    Ok(())
+  }
+
+  pub async fn export(
+    &mut self,
+    file_path: &str,
+    out_size: u32,
+    scene_count: usize,
+    speed: i32,
+  ) -> Result<()> {
+    //
+    // レンダリング先のテクスチャ
+    // surface.get_current_texture()を使って描画するテクスチャを取得する代わりに、テクスチャを自分で作成する
+    //
+    let texture_desc = wgpu::TextureDescriptor {
+      size: wgpu::Extent3d {
+        width: out_size,
+        height: out_size,
+        depth_or_array_layers: 1,
+      },
+      mip_level_count: 1,
+      sample_count: 1,
+      dimension: wgpu::TextureDimension::D2,
+      format: wgpu::TextureFormat::Rgba8UnormSrgb,
+      // TextureUsages::RENDER_ATTACHMENTを使って、wgpuがテクスチャにレンダリングできるようにする
+      // TextureUsages::COPY_SRCはテクスチャからデータを取り出してファイルに保存できるようにするため
+      usage: wgpu::TextureUsages::COPY_SRC
+        | wgpu::TextureUsages::RENDER_ATTACHMENT,
+      label: None,
+      view_formats: &[],
+    };
+    let texture = self.device.create_texture(&texture_desc);
+
+    //
+    // wgpuはテクスチャからバッファへのコピーがCOPY_BYTES_PER_ROW_ALIGNMENTを使用して整列されることを要求する
+    // このため、padded_bytes_per_rowとunpadded_bytes_per_rowの両方を保存する必要がある
+    //
+    let pixel_size = mem::size_of::<[u8; 4]>() as u32;
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let unpadded_bytes_per_row = pixel_size * out_size;
+    let padding = (align - unpadded_bytes_per_row % align) % align;
+    let padded_bytes_per_row = unpadded_bytes_per_row + padding;
+
+    //
+    // 出力をコピーするバッファを作成する
+    //
+    // 最終的に、テクスチャからバッファにデータをコピーしてファイルに保存する
+    // データを保存するためには、十分な大きさのバッファが必要
+    //
+    let buffer_size = (padded_bytes_per_row * out_size) as wgpu::BufferAddress;
+    let buffer_desc = wgpu::BufferDescriptor {
+      size: buffer_size,
+      // BufferUsages::MAP_READは、wpguにこのバッファをCPUから読み込みたいことを伝える
+      usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+      label: Some("Output Buffer"),
+      mapped_at_creation: false,
+    };
+    let output_buffer = self.device.create_buffer(&buffer_desc);
+
+    // フレームをレンダリングし、そのフレームをVec<u8>にコピーする
+    let mut frames = Vec::new();
+
+    for _ in 0..scene_count {
+      let mut command_encoder =
+        self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+          label: None,
+        });
+
+      // テクスチャに描画する
+      let submit = self.renderer.draw(
+        &command_encoder,
+        RenderTarget::Texture(&texture),
+        None,
+      )?;
+
+      // テクスチャの内容をバッファにコピーする
+      command_encoder.copy_texture_to_buffer(
+        wgpu::ImageCopyTexture {
+          texture: &texture,
+          mip_level: 0,
+          origin: wgpu::Origin3d::ZERO,
+          aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::ImageCopyBuffer {
+          buffer: &output_buffer,
+          layout: wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(padded_bytes_per_row),
+            rows_per_image: Some(out_size),
+          },
+        },
+        texture_desc.size,
+      );
+
+      submit(&self.queue);
+
+      //
+      // バッファからデータを取り出すには、まずバッファをマップし、バッファビューを取得して、それを&[u8]のように扱う必要がある
+      //
+      let buffer_slice = output_buffer.slice(..);
+      let (tx, rx) = futures_intrusive::channel::shared::oneshot_channel();
+      buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        tx.send(result).unwrap();
+      });
+      self.device.poll(wgpu::Maintain::Wait);
+
+      match rx.receive().await {
+        Some(Ok(())) => {
+          let padded_data = buffer_slice.get_mapped_range();
+          let data = padded_data
+            .chunks(padded_bytes_per_row as _)
+            .map(|chunk| &chunk[..unpadded_bytes_per_row as _])
+            .flatten()
+            .map(|x| *x)
+            .collect::<Vec<_>>();
+          drop(padded_data);
+          output_buffer.unmap();
+          frames.push(data);
+        }
+        _ => eprintln!("Something went wrong"),
+      }
+    }
+
+    self.save_gif(file_path, &mut frames, speed, out_size as u16)?;
+
+    Ok(())
+  }
+}
+
+pub struct App<'a, R>
+where
+  R: Render<'a>,
+{
+  window: Option<Arc<Window>>,
+  window_title: &'a str,
+  draw_data: R::DrawData,
+  initial_state: R::InitialState,
+  sample_count: u32,
+  ctx: Option<WgpuContext<'a>>,
+  renderer: Option<R>,
+  render_start_time: Option<time::Instant>,
+}
+
+impl<'a, R: Render<'a>> App<'a, R> {
+  pub fn new(
+    window_title: &'a str,
+    draw_data: R::DrawData,
+    initial_state: R::InitialState,
+    sample_count: Option<u32>,
+  ) -> Self {
+    Self {
+      window: None,
+      window_title,
+      draw_data,
+      initial_state,
+      sample_count: sample_count.unwrap_or(1),
+      ctx: None,
+      renderer: None,
+      render_start_time: None,
+    }
+  }
+
+  pub fn run(&mut self) -> Result<()> {
+    let event_loop = EventLoop::builder().build()?;
+    event_loop.run_app(self)?;
+
+    Ok(())
+  }
+
+  fn window(&self) -> Option<&Window> {
+    match &self.window {
+      Some(window) => Some(window.as_ref()),
+      None => None,
+    }
+  }
+
+  async fn init(&mut self, window: Arc<Window>) {
+    let ctx = WgpuContext::new(window, self.sample_count, None).await;
+    self.ctx = Some(ctx);
+
+    let renderer =
+      R::new(self.ctx.as_ref(), &self.draw_data, &self.initial_state).await;
+    self.renderer = Some(renderer);
+  }
+}
+
+impl<'a, R: Render<'a>> ApplicationHandler for App<'a, R> {
+  fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+    let window_attributes =
+      Window::default_attributes().with_title(self.window_title);
+    let window = event_loop.create_window(window_attributes).unwrap();
+    self.window = Some(Arc::new(window));
+
+    pollster::block_on(self.init(self.window.as_ref().unwrap().clone()));
+
+    self.render_start_time = Some(time::Instant::now());
+  }
+
+  fn window_event(
+    &mut self,
+    event_loop: &ActiveEventLoop,
+    window_id: WindowId,
+    event: WindowEvent,
+  ) {
+    let binding = self.window();
+    let window = match &binding {
+      Some(window) => window,
+      None => return,
+    };
+    if window.id() != window_id {
+      return;
+    }
+
+    let renderer = match &mut self.renderer {
+      Some(renderer) => renderer,
+      None => return,
+    };
+    if renderer.process_event(&event) {
+      return;
+    }
+
+    let ctx = match &mut self.ctx {
+      Some(ctx) => ctx,
+      None => return,
+    };
+
+    match event {
+      WindowEvent::Resized(size) => {
+        renderer.resize(ctx, size);
+      }
+      WindowEvent::RedrawRequested => {
+        let ctx = match &mut self.ctx {
+          Some(ctx) => ctx,
+          None => {
+            eprintln!("Context is not initialized");
+            return;
+          }
+        };
+
+        let now = time::Instant::now();
+        let dt = now - self.render_start_time.unwrap_or(now);
+        renderer.update(ctx, dt);
+
+        match renderer.draw(
+          &ctx.device,
+          RenderTarget::Surface(&ctx.surface),
+          Some(self.sample_count),
+        ) {
+          Ok((submit, _)) => {
+            submit(&ctx.queue);
+          }
+          // Err(wgpu::SurfaceError::Lost) => {
+          //   renderer.resize(ctx, renderer.get_size(&ctx))
+          // }
+          Err(wgpu::SurfaceError::OutOfMemory) => event_loop.exit(),
+          Err(e) => eprintln!("{:?}", e),
+        }
+      }
+      WindowEvent::CloseRequested => {
+        event_loop.exit();
+      }
+      WindowEvent::KeyboardInput {
+        event:
+          KeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::Escape),
+            state: ElementState::Pressed,
+            ..
+          },
+        ..
+      } => {
+        event_loop.exit();
+      }
+      _ => {}
+    }
+  }
+
+  fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+    let binding = self.window();
+    let window = match &binding {
+      Some(window) => window,
+      None => return,
+    };
+    window.request_redraw();
+  }
+}

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -161,7 +161,7 @@ where
     let render_start_time = time::Instant::now();
 
     for _ in 0..scene_count {
-      let mut command_encoder = self.ctx.device.create_command_encoder(
+      let command_encoder = self.ctx.device.create_command_encoder(
         &wgpu::CommandEncoderDescriptor { label: None },
       );
 

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -32,9 +32,6 @@ pub trait Render<'a> {
     draw_data: &Self::DrawData,
     initial_state: &Self::InitialState,
   ) -> impl Future<Output = Self>;
-  fn get_size(&self, ctx: &WgpuContext) -> PhysicalSize<u32> {
-    ctx.size
-  }
   fn resize(&mut self, ctx: &WgpuContext, size: Option<PhysicalSize<u32>>);
   fn process_event(&mut self, event: &WindowEvent) -> bool;
   fn update(&mut self, ctx: &WgpuContext, dt: time::Duration);

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -158,6 +158,7 @@ where
 
     // フレームをレンダリングし、そのフレームをVec<u8>にコピーする
     let mut frames = Vec::new();
+    let render_start_time = time::Instant::now();
 
     for _ in 0..scene_count {
       let mut command_encoder = self.ctx.device.create_command_encoder(
@@ -184,6 +185,10 @@ where
           texture_desc.size,
         );
       };
+
+      let now = time::Instant::now();
+      let dt = now - render_start_time;
+      self.renderer.update(&self.ctx, dt);
 
       // テクスチャに描画する
       let submit = self.renderer.draw(

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -47,22 +47,25 @@ pub trait Render<'a> {
   ) -> Result<impl FnOnce(&wgpu::Queue) -> (), wgpu::SurfaceError>;
 }
 
-// TODO: Appと同様の型パラメータ構成にできないか検討
 // TODO: GifでもMSAAに対応できないか実験
-pub struct Gif<'a, M, S, R>
+pub struct Gif<'a, R>
 where
-  R: Render<'a, DrawData = M, InitialState = S>,
+  R: Render<'a>,
 {
   renderer: R,
   size: u32,
   ctx: WgpuContext<'a>,
 }
 
-impl<'a, M, S, R> Gif<'a, M, S, R>
+impl<'a, R> Gif<'a, R>
 where
-  R: Render<'a, DrawData = M, InitialState = S>,
+  R: Render<'a>,
 {
-  pub async fn new(size: u32, draw_data: M, initial_state: S) -> Self {
+  pub async fn new(
+    size: u32,
+    draw_data: R::DrawData,
+    initial_state: R::InitialState,
+  ) -> Self {
     let ctx = WgpuContext::new_without_surface(
       size,
       size,

--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -119,8 +119,7 @@ where
       mip_level_count: 1,
       sample_count: 1,
       dimension: wgpu::TextureDimension::D2,
-      // TODO: self.ctx.formatを使うように変更
-      format: wgpu::TextureFormat::Rgba8UnormSrgb,
+      format: self.ctx.format,
       usage: wgpu::TextureUsages::COPY_SRC
         | wgpu::TextureUsages::RENDER_ATTACHMENT,
       label: None,

--- a/lib/wgpu_helper/src/lib.rs
+++ b/lib/wgpu_helper/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod binding;
 pub mod buffer;
+pub mod context;
 pub mod framework;
 pub mod model;
 pub mod transforms;

--- a/lib/wgpu_helper/src/wgpu_simplified.rs
+++ b/lib/wgpu_helper/src/wgpu_simplified.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use winit::window::Window;
 
+#[derive(Debug)]
 pub struct WgpuContext<'a> {
   pub instance: wgpu::Instance,
   pub surface: wgpu::Surface<'a>,

--- a/prototype/with_gif/Cargo.toml
+++ b/prototype/with_gif/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "with_gif"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow      = "1.0.89"
+bytemuck    = "1.19.0"
+cgmath      = "0.18.0"
+enum-rotate = "0.1.1"
+env_logger  = "0.11.5"
+wgpu        = "22.1.0"
+winit       = "0.30.5"
+wgpu_helper = { path = "../../lib/wgpu_helper" }
+pollster    = "0.3.0"
+rand        = "0.8.5"

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
 
   let mut gif: Gif<'_, Model, Initial, State> =
     Gif::new(512, model, initial).await;
-  gif.export("export/with_gif.gif", 512, 20, 10).await?;
+  gif.export("export/with_gif.gif", 20, 10).await?;
 
   Ok(())
 }

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -60,8 +60,8 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
   };
 
   let mut gif: Gif<'_, Model, Initial, State> =
-    Gif::new(512, model, initial).await;
-  gif.export("export/with_gif.gif", 20, 10).await?;
+    Gif::new(1024, model, initial).await;
+  gif.export("export/with_gif.gif", 50, 30).await?;
 
   Ok(())
 }

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -406,17 +406,4 @@ impl<'a> Render<'a> for State {
 
     Ok(submit)
   }
-
-  // fn submit(&self, queue: &wgpu::Queue, output: DrawOutput) {
-  //   let DrawOutput {
-  //     encoder,
-  //     surface_texture,
-  //   } = output;
-
-  //   queue.submit(iter::once(encoder.finish()));
-
-  //   if let Some(frame) = surface_texture {
-  //     frame.present();
-  //   }
-  // }
 }

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -33,7 +33,7 @@ pub fn run(title: &str) -> Result<(), Box<dyn Error>> {
     rotation_speed: 1.,
   };
 
-  let mut app: App<State> = App::new(title, model, initial, Some(1));
+  let mut app: App<State> = App::new(title, model, initial, Some(4));
   app.run()?;
 
   Ok(())
@@ -59,8 +59,8 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
     rotation_speed: 2.5,
   };
 
-  let mut gif = Gif::<State>::new(1024, model, initial).await;
-  gif.export("export/with_gif-1.gif", 50, 1).await?;
+  let mut gif = Gif::<State>::new(1024, model, initial, Some(4)).await;
+  gif.export("export/with_gif-msaa.gif", 50, 1).await?;
 
   Ok(())
 }
@@ -342,7 +342,7 @@ impl<'a> Render<'a> for State {
     &mut self,
     mut encoder: wgpu::CommandEncoder,
     target: RenderTarget,
-    sample_count: Option<u32>,
+    sample_count: u32,
     before_submit_hook: impl FnOnce(&mut wgpu::CommandEncoder) -> (),
   ) -> anyhow::Result<impl FnOnce(&wgpu::Queue) -> (), wgpu::SurfaceError> {
     let (view, frame) = match target {
@@ -361,7 +361,7 @@ impl<'a> Render<'a> for State {
     let color_attach = ws::create_color_attachment(&view);
     let msaa_attach =
       ws::create_msaa_color_attachment(&view, &self.msaa_texture_view);
-    let color_attachment = if sample_count.unwrap_or(1) == 1 {
+    let color_attachment = if sample_count == 1 {
       color_attach
     } else {
       msaa_attach

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -59,8 +59,7 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
     rotation_speed: 2.5,
   };
 
-  let mut gif: Gif<'_, Model, Initial, State> =
-    Gif::new(1024, model, initial).await;
+  let mut gif = Gif::<State>::new(1024, model, initial).await;
   gif.export("export/with_gif-1.gif", 50, 1).await?;
 
   Ok(())

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -1,0 +1,431 @@
+use std::error::Error;
+use std::f32::consts::PI;
+use std::{iter, mem, time};
+
+use bytemuck::{Pod, Zeroable};
+use cgmath::*;
+use wgpu::util::DeviceExt;
+use wgpu_helper::framework::with_gif::{
+  App, DrawOutput, Gif, Render, RenderTarget,
+};
+use wgpu_helper::transforms as wt;
+use wgpu_helper::vertex_data as vd;
+use wgpu_helper::vertex_data::cube::Cube;
+use wgpu_helper::wgpu_simplified::{self as ws, WgpuContext};
+use winit::dpi::PhysicalSize;
+use winit::event::WindowEvent;
+
+pub fn run(title: &str) -> Result<(), Box<dyn Error>> {
+  env_logger::init();
+
+  let (vertex_data, index_data) = create_vertices();
+
+  let model = Model {
+    vertex_data,
+    index_data,
+  };
+
+  let initial = Initial {
+    camera_position: Point3::new(3., 1.5, 3.),
+    look_direction: Point3::new(0., 0., 0.),
+    up_direction: Vector3::unit_y(),
+    specular_color: [1., 1., 1.],
+    object_color: [0.855, 0.792, 0.969],
+    material: Material::default(),
+    rotation_speed: 1.,
+  };
+
+  let mut app: App<State> = App::new(title, model, initial, Some(1));
+  app.run()?;
+
+  Ok(())
+}
+
+pub async fn export_gif() -> Result<(), Box<dyn Error>> {
+  env_logger::init();
+
+  let (vertex_data, index_data) = create_vertices();
+
+  let model = Model {
+    vertex_data,
+    index_data,
+  };
+
+  let initial = Initial {
+    camera_position: Point3::new(3., 1.5, 3.),
+    look_direction: Point3::new(0., 0., 0.),
+    up_direction: Vector3::unit_y(),
+    specular_color: [1., 1., 1.],
+    object_color: [0.855, 0.792, 0.969],
+    material: Material::default(),
+    rotation_speed: 1.,
+  };
+
+  let mut gif: Gif<'_, Model, Initial, State> = Gif::new(model, initial).await;
+  gif.export("prototype/with_gif", 512, 20, 10).await?;
+
+  Ok(())
+}
+
+struct Model {
+  pub vertex_data: Vec<Vertex>,
+  pub index_data: Vec<u16>,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct Vertex {
+  pub position: [f32; 3],
+  pub normal: [f32; 3],
+}
+fn create_vertices() -> (Vec<Vertex>, Vec<u16>) {
+  let Cube {
+    positions,
+    normals,
+    indices,
+    ..
+  } = vd::cube::create_cube_data(2.);
+
+  let data = (0..positions.len())
+    .map(|i| Vertex {
+      position: positions[i],
+      normal: normals[i],
+    })
+    .collect::<Vec<Vertex>>();
+
+  (data, indices)
+}
+
+struct Initial {
+  pub camera_position: Point3<f32>,
+  pub look_direction: Point3<f32>,
+  pub up_direction: Vector3<f32>,
+  pub specular_color: [f32; 3],
+  pub object_color: [f32; 3],
+  pub material: Material,
+  pub rotation_speed: f32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+struct Material {
+  ambient_intensity: f32,
+  diffuse_intensity: f32,
+  specular_intensity: f32,
+  specular_shininess: f32,
+}
+impl Default for Material {
+  fn default() -> Self {
+    Self {
+      ambient_intensity: 0.2,
+      diffuse_intensity: 0.8,
+      specular_intensity: 0.4,
+      specular_shininess: 30.,
+    }
+  }
+}
+
+struct State {
+  /// drawing context
+  pipeline: wgpu::RenderPipeline,
+
+  /// model data
+  vertex_buffer: wgpu::Buffer,
+  index_buffer: wgpu::Buffer,
+  indices_len: u32,
+
+  /// uniforms
+  uniform_bind_groups: Vec<wgpu::BindGroup>,
+  matrix_uniform_buffer: wgpu::Buffer,
+
+  /// textures
+  msaa_texture_view: wgpu::TextureView,
+  depth_texture_view: wgpu::TextureView,
+
+  /// transformation matrices
+  view_mat: Matrix4<f32>,
+  project_mat: Matrix4<f32>,
+
+  /// rendering settings
+  rotation_speed: f32,
+}
+
+impl<'a> Render<'a> for State {
+  type DrawData = Model;
+  type InitialState = Initial;
+
+  async fn new(
+    ctx: Option<&ws::WgpuContext<'a>>,
+    model: &Model,
+    initial: &Initial,
+  ) -> Self {
+    let ctx = match ctx {
+      Some(ctx) => ctx,
+      None => {
+        panic!("Failed to create a wgpu context");
+      }
+    };
+
+    let vs_shader = ctx
+      .device
+      .create_shader_module(wgpu::include_wgsl!("./shader-vert.wgsl"));
+    let fs_shader = ctx
+      .device
+      .create_shader_module(wgpu::include_wgsl!("./shader-frag.wgsl"));
+
+    let aspect = ctx.config.width as f32 / ctx.config.height as f32;
+    let view_mat = wt::create_view_mat(
+      initial.camera_position,
+      initial.look_direction,
+      initial.up_direction,
+    );
+    let project_mat =
+      wt::create_perspective_mat(Rad(2. * PI / 5.), aspect, 1., 1000.);
+
+    let matrix_uniform_buffer =
+      ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Matrix Uniform Buffer"),
+        size: (mem::size_of::<[f32; 16]>() * 3) as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+      });
+
+    let light_position: &[f32; 3] = initial.camera_position.as_ref();
+    let eye_position: &[f32; 3] = initial.camera_position.as_ref();
+
+    let light_uniform_buffer =
+      ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Light Uniform Buffer 1"),
+        size: (mem::size_of::<[f32; 4]>() * 4) as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+      });
+    ctx.queue.write_buffer(
+      &light_uniform_buffer,
+      4 * 4 * 0,
+      bytemuck::cast_slice(light_position),
+    );
+    ctx.queue.write_buffer(
+      &light_uniform_buffer,
+      4 * 4 * 1,
+      bytemuck::cast_slice(eye_position),
+    );
+    ctx.queue.write_buffer(
+      &light_uniform_buffer,
+      4 * 4 * 2,
+      bytemuck::cast_slice(initial.specular_color.as_ref()),
+    );
+    ctx.queue.write_buffer(
+      &light_uniform_buffer,
+      4 * 4 * 3,
+      bytemuck::cast_slice(initial.object_color.as_ref()),
+    );
+
+    let material_uniform_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Material Uniform Buffer"),
+        contents: bytemuck::cast_slice(&[
+          initial.material.ambient_intensity,
+          initial.material.diffuse_intensity,
+          initial.material.specular_intensity,
+          initial.material.specular_shininess,
+        ]),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+      });
+
+    let (vert_bind_group_layout, vert_bind_group) =
+      ws::create_uniform_bind_group(
+        &ctx.device,
+        vec![wgpu::ShaderStages::VERTEX],
+        &[matrix_uniform_buffer.as_entire_binding()],
+      );
+
+    let (frag_bind_group_layout, frag_bind_group) =
+      ws::create_uniform_bind_group(
+        &ctx.device,
+        vec![wgpu::ShaderStages::FRAGMENT, wgpu::ShaderStages::FRAGMENT],
+        &[
+          light_uniform_buffer.as_entire_binding(),
+          material_uniform_buffer.as_entire_binding(),
+        ],
+      );
+
+    let vertex_buffer_layout = wgpu::VertexBufferLayout {
+      array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
+      step_mode: wgpu::VertexStepMode::Vertex,
+      attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3],
+    };
+    let pipeline_layout =
+      ctx.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Render Pipeline Layout"),
+        bind_group_layouts: &[&vert_bind_group_layout, &frag_bind_group_layout],
+        push_constant_ranges: &[],
+      });
+    let mut render = ws::RenderSet {
+      vs_shader: Some(&vs_shader),
+      fs_shader: Some(&fs_shader),
+      pipeline_layout: Some(&pipeline_layout),
+      vertex_buffer_layout: &[vertex_buffer_layout],
+      ..Default::default()
+    };
+    let pipeline = render.new(&ctx);
+
+    let msaa_texture_view = ws::create_msaa_texture_view(&ctx);
+    let depth_texture_view = ws::create_depth_view(&ctx);
+
+    let vertex_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Vertex Buffer"),
+        contents: bytemuck::cast_slice(&model.vertex_data),
+        usage: wgpu::BufferUsages::VERTEX,
+      });
+
+    let index_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Index Buffer"),
+        contents: bytemuck::cast_slice(&model.index_data),
+        usage: wgpu::BufferUsages::INDEX,
+      });
+
+    Self {
+      pipeline,
+      vertex_buffer: vertex_buffer.into(),
+      index_buffer: index_buffer.into(),
+      uniform_bind_groups: vec![vert_bind_group, frag_bind_group],
+      matrix_uniform_buffer,
+      view_mat,
+      project_mat,
+      msaa_texture_view,
+      depth_texture_view,
+      indices_len: model.index_data.len() as u32,
+      rotation_speed: initial.rotation_speed,
+    }
+  }
+
+  fn resize(&mut self, ctx: &mut ws::WgpuContext<'_>, size: PhysicalSize<u32>) {
+    if size.width > 0 && size.height > 0 {
+      ctx.surface.configure(&ctx.device, &ctx.config);
+
+      self.project_mat =
+        wt::create_projection_mat(size.width as f32 / size.height as f32, true);
+
+      self.depth_texture_view = ws::create_depth_view(ctx);
+
+      if ctx.sample_count > 1 {
+        self.msaa_texture_view = ws::create_msaa_texture_view(&ctx);
+      }
+    }
+  }
+
+  fn process_event(&mut self, _event: &WindowEvent) -> bool {
+    false
+  }
+
+  fn update(&mut self, ctx: &ws::WgpuContext, dt: time::Duration) {
+    let dt = self.rotation_speed * dt.as_secs_f32();
+
+    let model_mat =
+      wt::create_model_mat_with_rotation([dt.sin(), dt.cos(), 0.]);
+    let view_proj_mat = self.project_mat * self.view_mat;
+    let normal_mat = (model_mat.invert().unwrap()).transpose();
+
+    let model_ref: &[f32; 16] = model_mat.as_ref();
+    let view_proj_ref: &[f32; 16] = view_proj_mat.as_ref();
+    let normal_ref: &[f32; 16] = normal_mat.as_ref();
+
+    ctx.queue.write_buffer(
+      &self.matrix_uniform_buffer,
+      16 * 4 * 0,
+      bytemuck::cast_slice(view_proj_ref),
+    );
+    ctx.queue.write_buffer(
+      &self.matrix_uniform_buffer,
+      16 * 4 * 1,
+      bytemuck::cast_slice(model_ref),
+    );
+    ctx.queue.write_buffer(
+      &self.matrix_uniform_buffer,
+      16 * 4 * 2,
+      bytemuck::cast_slice(normal_ref),
+    );
+  }
+
+  fn draw(
+    &mut self,
+    device: &wgpu::Device,
+    target: RenderTarget,
+    sample_count: Option<u32>,
+  ) -> anyhow::Result<
+    (impl FnOnce(&wgpu::Queue) -> (), &mut wgpu::CommandEncoder),
+    wgpu::SurfaceError,
+  > {
+    let mut encoder = device
+      .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+    let (view, frame) = match target {
+      RenderTarget::Surface(surface) => {
+        let frame = surface.get_current_texture()?;
+        let view =
+          frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (view, Some(frame))
+      }
+      RenderTarget::Texture(texture) => {
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (view, None)
+      }
+    };
+
+    let color_attach = ws::create_color_attachment(&view);
+    let msaa_attach =
+      ws::create_msaa_color_attachment(&view, &self.msaa_texture_view);
+    let color_attachment = if sample_count.unwrap_or(1) == 1 {
+      color_attach
+    } else {
+      msaa_attach
+    };
+    let depth_attachment =
+      ws::create_depth_stencil_attachment(&self.depth_texture_view);
+
+    let mut render_pass =
+      encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("Render Pass"),
+        color_attachments: &[Some(color_attachment)],
+        depth_stencil_attachment: Some(depth_attachment),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+      });
+
+    render_pass.set_pipeline(&self.pipeline);
+    render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+    render_pass
+      .set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+    render_pass.set_bind_group(0, &self.uniform_bind_groups[0], &[]);
+    render_pass.set_bind_group(1, &self.uniform_bind_groups[1], &[]);
+    render_pass.draw_indexed(0..self.indices_len, 0, 0..1);
+
+    drop(render_pass);
+
+    let submit = |queue: &wgpu::Queue| {
+      queue.submit(iter::once(encoder.finish()));
+
+      if let Some(frame) = frame {
+        frame.present();
+      }
+    };
+
+    Ok((submit, &mut encoder))
+  }
+
+  fn submit(&self, queue: &wgpu::Queue, output: DrawOutput) {
+    let DrawOutput {
+      encoder,
+      surface_texture,
+    } = output;
+
+    queue.submit(iter::once(encoder.finish()));
+
+    if let Some(frame) = surface_texture {
+      frame.present();
+    }
+  }
+}

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -215,12 +215,7 @@ impl<'a> Render<'a> for State {
     let material_uniform_buffer =
       ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("Material Uniform Buffer"),
-        contents: bytemuck::cast_slice(&[
-          initial.material.ambient_intensity,
-          initial.material.diffuse_intensity,
-          initial.material.specular_intensity,
-          initial.material.specular_shininess,
-        ]),
+        contents: bytemuck::cast_slice(&[initial.material]),
         usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
       });
 

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -56,12 +56,12 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
     specular_color: [1., 1., 1.],
     object_color: [0.855, 0.792, 0.969],
     material: Material::default(),
-    rotation_speed: 1.,
+    rotation_speed: 2.5,
   };
 
   let mut gif: Gif<'_, Model, Initial, State> =
     Gif::new(1024, model, initial).await;
-  gif.export("export/with_gif.gif", 50, 30).await?;
+  gif.export("export/with_gif-1.gif", 50, 1).await?;
 
   Ok(())
 }

--- a/prototype/with_gif/src/shader-frag.wgsl
+++ b/prototype/with_gif/src/shader-frag.wgsl
@@ -1,0 +1,45 @@
+struct LightUniforms {
+  light_position: vec3f,
+  eye_position: vec3f,
+  color: vec3f,
+  specular_color: vec3f,
+}
+
+@binding(0) @group(1) var<uniform> light: LightUniforms;
+
+struct MaterialUniforms {
+  ambient: f32,
+  diffuse: f32,
+  specular: f32,
+  shininess: f32,
+}
+
+@binding(1) @group(1) var<uniform> material: MaterialUniforms;
+
+fn blinn_phong(N: vec3f, L: vec3f, V: vec3f) -> vec2f {
+  let H = normalize(L + V);
+  var diffuse = material.diffuse * max(dot(N, L), 0.0);
+  diffuse += material.diffuse * max(dot(-N, L), 0.0);
+  var specular = material.specular * pow(max(dot(N, H), 0.0), material.shininess);
+  specular += material.specular * pow(max(dot(-N, H), 0.0), material.shininess);
+  return vec2(diffuse, specular);
+}
+
+struct Varyings {
+  @location(0) v_position: vec4f,
+  @location(1) v_normal: vec4f,
+}
+
+@fragment
+fn fs_main(in: Varyings) -> @location(0) vec4f {
+  var N = normalize(in.v_normal.xyz);
+  let L = normalize(light.light_position.xyz - in.v_position.xyz);
+  let V = normalize(light.eye_position.xyz - in.v_position.xyz);
+  
+  let bp = blinn_phong(N, L, V);
+  let diffuse = bp[0];
+  let specular = bp[1];
+  
+  let final_color = light.color * (material.ambient + diffuse) + light.specular_color * specular;
+  return vec4(final_color.rgb, 1.0);
+}

--- a/prototype/with_gif/src/shader-vert.wgsl
+++ b/prototype/with_gif/src/shader-vert.wgsl
@@ -1,0 +1,29 @@
+struct Uniforms {
+  view_project_mat: mat4x4f,
+  model_mat: mat4x4f,
+  normal_mat: mat4x4f,
+};
+
+@binding(0) @group(0) var<uniform> unif: Uniforms;
+
+struct Input {
+  @location(0) pos: vec3f,
+  @location(1) normal: vec3f,
+}
+
+struct Output {
+  @builtin(position) position: vec4f,
+  @location(0) v_position: vec4f,
+  @location(1) v_normal: vec4f,
+}
+
+@vertex
+fn vs_main(in: Input) -> Output {
+  var output: Output;
+    
+  let m_position = unif.model_mat * vec4(in.pos, 1.0);
+  output.v_position = m_position;
+  output.v_normal = unif.normal_mat * vec4(in.normal, 1.0);
+  output.position = unif.view_project_mat * m_position;
+  return output;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     "prototype/rect-renderer" => rect_renderer::run(),
     "prototype/text-renderer" => text_renderer::proto(),
     "prototype/with_gif" => Ok(with_gif::run("with_gif")?),
+    "export/with_gif" => Ok(pollster::block_on(with_gif::export_gif())?),
     "practice/cube_blinn_phong" => {
       Ok(cube_blinn_phong::run("cube_blinn_phong")?)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     "tutorial/hello-glyphon" => hello_glyphon::run(),
     "prototype/rect-renderer" => rect_renderer::run(),
     "prototype/text-renderer" => text_renderer::proto(),
+    "prototype/with_gif" => Ok(with_gif::run("with_gif")?),
     "practice/cube_blinn_phong" => {
       Ok(cube_blinn_phong::run("cube_blinn_phong")?)
     }


### PR DESCRIPTION
## windowへの描画

<img width="912" alt="スクリーンショット 2024-10-24 13 26 58" src="https://github.com/user-attachments/assets/b8e3c9bc-937c-461a-a043-92893ab7f273">

## エクスポートしたgif

### MSAAなし

![with_gif-1](https://github.com/user-attachments/assets/9b79e80a-8593-49b5-a9cc-98a8227b60ff)

### MSAAあり

![with_gif-msaa-1](https://github.com/user-attachments/assets/02110af1-391b-4b41-b372-14d6b0a70c8f)

