### PR TITLE
helper: Gifのmsaa指定方法を変更

### DIFF
--- a/lib/wgpu_helper/src/framework/with_gif.rs
+++ b/lib/wgpu_helper/src/framework/with_gif.rs
@@ -77,12 +77,8 @@ impl<'a, R> Gif<'a, R>
 where
   R: Render<'a>,
 {
-  pub async fn new(
-    size: u32,
-    initial: R::Initial,
-    sample_count: Option<u32>,
-  ) -> Self {
-    let sample_count = sample_count.unwrap_or(1);
+  pub async fn new(size: u32, initial: R::Initial, msaa: bool) -> Self {
+    let sample_count = if msaa { 4 } else { 1 };
 
     let ctx = WgpuContext::new_without_surface(
       size,

--- a/prototype/with_gif/src/lib.rs
+++ b/prototype/with_gif/src/lib.rs
@@ -58,8 +58,8 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
     rotation_speed: 2.5,
   };
 
-  let mut gif = Gif::<State>::new(1024, initial, Some(4)).await;
-  gif.export("export/with_gif-msaa-3.gif", 50, 1).await?;
+  let mut gif = Gif::<State>::new(1024, initial, true).await;
+  gif.export("export/with_gif-msaa-4.gif", 50, 1).await?;
 
   Ok(())
 }

--- a/with_gif/life_game/src/lib.rs
+++ b/with_gif/life_game/src/lib.rs
@@ -41,8 +41,8 @@ pub async fn export_gif() -> Result<(), Box<dyn Error>> {
 
   let initial = setup();
 
-  let mut gif = Gif::<State>::new(512, initial, Some(4)).await;
-  gif.export("export/with_gif-lige_game-2.gif", 30, 10).await?;
+  let mut gif = Gif::<State>::new(512, initial, false).await;
+  gif.export("export/with_gif-lige_game-3.gif", 30, 10).await?;
 
   Ok(())
 }


### PR DESCRIPTION
- Optionで包んだsample_countではなく、msaaを有効化するかを表すboolフラグで指定するように
  - 現状、4以外のsample_countを指定すると多くの環境でクラッシュするため
- Gifではnew内部でctxを生成しているため、Appと同様にwith_msaaメソッドに指定を分離するのは難しかった
- life_gameのGif生成でmsaaが有効化されていたが、不要なので無効に変更