### PR TITLE
wgsim: SurfaceConfigBuilderを追加し、APIを整理

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,6 @@ dependencies = [
  "rand",
  "wgpu 22.1.0",
  "wgsim",
- "winit",
 ]
 
 [[package]]
@@ -1377,7 +1376,6 @@ dependencies = [
  "rand",
  "wgpu 22.1.0",
  "wgsim",
- "winit",
 ]
 
 [[package]]
@@ -1391,7 +1389,6 @@ dependencies = [
  "rand",
  "wgpu 22.1.0",
  "wgsim",
- "winit",
 ]
 
 [[package]]
@@ -4007,7 +4004,6 @@ dependencies = [
  "rand",
  "wgpu 22.1.0",
  "wgsim",
- "winit",
 ]
 
 [[package]]

--- a/instanced_cube_sphere_torus/base/Cargo.toml
+++ b/instanced_cube_sphere_torus/base/Cargo.toml
@@ -10,7 +10,6 @@ cgmath      = "0.18.0"
 enum-rotate = "0.1.1"
 env_logger  = "0.11.5"
 wgpu        = "22.1.0"
-winit       = "0.30.5"
 wgsim       = { path = "../../lib/wgsim" }
 pollster    = "0.3.0"
 rand        = "0.8.5"

--- a/instanced_cube_sphere_torus/base/src/lib.rs
+++ b/instanced_cube_sphere_torus/base/src/lib.rs
@@ -7,12 +7,11 @@ use cgmath::{Matrix4, Point3, Vector3};
 use instance_defs::{Matrices, Shapes, Vertex};
 use wgpu::util::DeviceExt;
 use wgsim::app::App;
-use wgsim::ctx::WgpuContext;
+use wgsim::ctx::{DrawingContext, Size};
 use wgsim::matrix;
 use wgsim::ppl::RenderPipelineBuilder;
 use wgsim::render::{Render, RenderTarget};
 use wgsim::util;
-use winit::dpi::PhysicalSize;
 
 const NUM_CUBES: u32 = 50;
 const NUM_SPHERES: u32 = 50;
@@ -60,7 +59,7 @@ struct State {
 impl<'a> Render<'a> for State {
   type Initial = Initial;
 
-  async fn new(ctx: &WgpuContext<'a>, initial: &Self::Initial) -> Self {
+  async fn new(ctx: &DrawingContext<'a>, initial: &Self::Initial) -> Self {
     //
     // shader
     //
@@ -77,7 +76,7 @@ impl<'a> Render<'a> for State {
     //
 
     let objects_count = NUM_CUBES + NUM_SPHERES + NUM_TORI;
-    let aspect = ctx.size.width as f32 / ctx.size.height as f32;
+    let aspect = ctx.aspect_ratio();
 
     let Matrices {
       model_mat,
@@ -204,13 +203,9 @@ impl<'a> Render<'a> for State {
     }
   }
 
-  fn resize(&mut self, ctx: &WgpuContext<'_>, size: Option<PhysicalSize<u32>>) {
-    let size = size.unwrap_or(ctx.size);
-
+  fn resize(&mut self, ctx: &mut DrawingContext<'_>, size: Size) {
     if size.width > 0 && size.height > 0 {
-      if let Some(surface) = &ctx.surface {
-        surface.configure(&ctx.device, &ctx.config.as_ref().unwrap());
-      }
+      ctx.resize(size.into());
 
       self.project_mat = matrix::create_projection_mat(
         size.width as f32 / size.height as f32,

--- a/instanced_cube_sphere_torus/direction_light_1/Cargo.toml
+++ b/instanced_cube_sphere_torus/direction_light_1/Cargo.toml
@@ -10,7 +10,6 @@ cgmath      = "0.18.0"
 enum-rotate = "0.1.1"
 env_logger  = "0.11.5"
 wgpu        = "22.1.0"
-winit       = "0.30.5"
 wgsim       = { path = "../../lib/wgsim" }
 pollster    = "0.3.0"
 rand        = "0.8.5"

--- a/instanced_cube_sphere_torus/direction_light_2/Cargo.toml
+++ b/instanced_cube_sphere_torus/direction_light_2/Cargo.toml
@@ -8,7 +8,6 @@ bytemuck   = "1.19.0"
 cgmath     = "0.18.0"
 env_logger = "0.11.5"
 wgpu       = "22.1.0"
-winit      = "0.30.5"
 wgsim      = { path = "../../lib/wgsim" }
 pollster   = "0.3.0"
 rand       = "0.8.5"

--- a/instanced_cube_sphere_torus/direction_light_2/src/lib.rs
+++ b/instanced_cube_sphere_torus/direction_light_2/src/lib.rs
@@ -9,13 +9,12 @@ use instance_defs::{Matrices, Shapes, Vertex};
 use light_defs::DirectionLight;
 use wgpu::util::DeviceExt;
 use wgsim::app::App;
-use wgsim::ctx::WgpuContext;
+use wgsim::ctx::{DrawingContext, Size};
 use wgsim::export::Gif;
 use wgsim::matrix;
 use wgsim::ppl::RenderPipelineBuilder;
 use wgsim::render::{Render, RenderTarget};
 use wgsim::util;
-use winit::dpi::PhysicalSize;
 
 const NUM_CUBES: u32 = 50;
 const NUM_SPHERES: u32 = 50;
@@ -101,7 +100,7 @@ struct State {
 impl<'a> Render<'a> for State {
   type Initial = Initial;
 
-  async fn new(ctx: &WgpuContext<'a>, initial: &Self::Initial) -> Self {
+  async fn new(ctx: &DrawingContext<'a>, initial: &Self::Initial) -> Self {
     //
     // shader
     //
@@ -118,7 +117,7 @@ impl<'a> Render<'a> for State {
     //
 
     let objects_count = NUM_CUBES + NUM_SPHERES + NUM_TORI;
-    let aspect = ctx.size.width as f32 / ctx.size.height as f32;
+    let aspect = ctx.aspect_ratio();
 
     let Matrices {
       model_mat,
@@ -297,13 +296,9 @@ impl<'a> Render<'a> for State {
     }
   }
 
-  fn resize(&mut self, ctx: &WgpuContext<'_>, size: Option<PhysicalSize<u32>>) {
-    let size = size.unwrap_or(ctx.size);
-
+  fn resize(&mut self, ctx: &mut DrawingContext<'_>, size: Size) {
     if size.width > 0 && size.height > 0 {
-      if let Some(surface) = &ctx.surface {
-        surface.configure(&ctx.device, &ctx.config.as_ref().unwrap());
-      }
+      ctx.resize(size.into());
 
       self.project_mat = matrix::create_projection_mat(
         size.width as f32 / size.height as f32,
@@ -318,7 +313,7 @@ impl<'a> Render<'a> for State {
     }
   }
 
-  fn update(&mut self, ctx: &WgpuContext, dt: std::time::Duration) {
+  fn update(&mut self, ctx: &DrawingContext, dt: std::time::Duration) {
     let dt = self.animation_speed * dt.as_secs_f32();
     let sin = 10.0 * (0.5 + dt.sin());
     let cos = 10.0 * (0.5 + dt.cos());

--- a/lib/wgsim/src/lib.rs
+++ b/lib/wgsim/src/lib.rs
@@ -5,4 +5,5 @@ pub mod geometry;
 pub mod matrix;
 pub mod ppl;
 pub mod render;
+pub mod surface_cfg;
 pub mod util;

--- a/lib/wgsim/src/ppl.rs
+++ b/lib/wgsim/src/ppl.rs
@@ -1,7 +1,7 @@
-use crate::ctx::WgpuContext;
+use crate::ctx::DrawingContext;
 
 pub struct RenderPipelineBuilder<'a> {
-  ctx: &'a WgpuContext<'a>,
+  ctx: &'a DrawingContext<'a>,
   pipeline_layout: Option<&'a wgpu::PipelineLayout>,
 
   depth_stencil: Option<wgpu::DepthStencilState>,
@@ -18,7 +18,7 @@ pub struct RenderPipelineBuilder<'a> {
 }
 
 impl<'a> RenderPipelineBuilder<'a> {
-  pub fn new(ctx: &'a WgpuContext) -> Self {
+  pub fn new(ctx: &'a DrawingContext) -> Self {
     Self {
       ctx,
       depth_stencil: None,
@@ -28,7 +28,7 @@ impl<'a> RenderPipelineBuilder<'a> {
       fs_shader: None,
       fs_entry: "fs_main",
       vertex_buffer_layout: &[],
-      targets: vec![Some(ctx.format.into())],
+      targets: vec![Some(ctx.format().into())],
       primitive: wgpu::PrimitiveState::default(),
     }
   }

--- a/lib/wgsim/src/render.rs
+++ b/lib/wgsim/src/render.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
 
-use winit::{dpi::PhysicalSize, event::WindowEvent};
+use winit::event::WindowEvent;
 
-use crate::ctx::WgpuContext;
+use crate::ctx::{DrawingContext, Size};
 
 pub enum RenderTarget<'a> {
   Surface(&'a wgpu::Surface<'a>),
@@ -14,22 +14,18 @@ pub trait Render<'a> {
   type Initial;
 
   fn new(
-    ctx: &WgpuContext<'a>,
+    ctx: &DrawingContext<'a>,
     initial: &Self::Initial,
   ) -> impl Future<Output = Self>;
-  fn resize(&mut self, ctx: &WgpuContext, size: Option<PhysicalSize<u32>>) {
-    let size = size.unwrap_or(ctx.size);
-
+  fn resize(&mut self, ctx: &mut DrawingContext, size: Size) {
     if size.width > 0 && size.height > 0 {
-      if let Some(surface) = &ctx.surface {
-        surface.configure(&ctx.device, &ctx.config.as_ref().unwrap());
-      }
+      ctx.resize(size);
     }
   }
   fn process_event(&mut self, event: &WindowEvent) -> bool {
     false
   }
-  fn update(&mut self, ctx: &WgpuContext, dt: std::time::Duration) {}
+  fn update(&mut self, ctx: &DrawingContext, dt: std::time::Duration) {}
   fn draw(
     &mut self,
     encoder: &mut wgpu::CommandEncoder,

--- a/lib/wgsim/src/surface_cfg.rs
+++ b/lib/wgsim/src/surface_cfg.rs
@@ -1,0 +1,52 @@
+pub struct SurfaceConfigBuilder<'a> {
+  usage: wgpu::TextureUsages,
+  format: Option<wgpu::TextureFormat>,
+  present_mode: wgpu::PresentMode,
+  alpha_mode: Option<wgpu::CompositeAlphaMode>,
+  view_formats: &'a [wgpu::TextureFormat],
+  desired_maximum_frame_latency: u32,
+}
+
+impl<'a> SurfaceConfigBuilder<'a> {
+  pub fn new() -> Self {
+    Self {
+      usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+      format: None,
+      present_mode: wgpu::PresentMode::Fifo,
+      alpha_mode: None,
+      view_formats: &[],
+      desired_maximum_frame_latency: 2,
+    }
+  }
+
+  pub fn format(mut self, format: wgpu::TextureFormat) -> Self {
+    self.format = Some(format);
+    self
+  }
+
+  pub fn alpha_mode(mut self, mode: wgpu::CompositeAlphaMode) -> Self {
+    self.alpha_mode = Some(mode);
+    self
+  }
+
+  pub fn build(
+    &self,
+    adapter: &'a wgpu::Adapter,
+    surface: &wgpu::Surface,
+    width: u32,
+    height: u32,
+  ) -> wgpu::SurfaceConfiguration {
+    let surface_caps = surface.get_capabilities(&adapter);
+
+    wgpu::SurfaceConfiguration {
+      usage: self.usage,
+      format: self.format.unwrap_or(surface_caps.formats[0]),
+      width,
+      height,
+      present_mode: self.present_mode,
+      alpha_mode: self.alpha_mode.unwrap_or(surface_caps.alpha_modes[0]),
+      view_formats: self.view_formats.to_vec(),
+      desired_maximum_frame_latency: self.desired_maximum_frame_latency,
+    }
+  }
+}

--- a/lib/wgsim/src/util.rs
+++ b/lib/wgsim/src/util.rs
@@ -1,4 +1,4 @@
-use crate::ctx::WgpuContext;
+use crate::ctx::DrawingContext;
 
 pub fn create_bind_group_layout_for_buffer(
   device: &wgpu::Device,
@@ -75,18 +75,20 @@ pub fn create_color_attachment(
   }
 }
 
-pub fn create_msaa_texture_view(init: &WgpuContext) -> wgpu::TextureView {
+pub fn create_msaa_texture_view(init: &DrawingContext) -> wgpu::TextureView {
+  let size = init.size();
+
   let msaa_texture = init.device.create_texture(&wgpu::TextureDescriptor {
     label: None,
     size: wgpu::Extent3d {
-      width: init.size.width,
-      height: init.size.height,
+      width: size.width,
+      height: size.height,
       depth_or_array_layers: 1,
     },
     mip_level_count: 1,
     sample_count: init.sample_count,
     dimension: wgpu::TextureDimension::D2,
-    format: init.format,
+    format: init.format(),
     usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
     view_formats: &[],
   });
@@ -108,12 +110,14 @@ pub fn create_msaa_color_attachment<'a>(
   }
 }
 
-pub fn create_depth_view(init: &WgpuContext) -> wgpu::TextureView {
+pub fn create_depth_view(init: &DrawingContext) -> wgpu::TextureView {
+  let size = init.size();
+
   let depth_texture = init.device.create_texture(&wgpu::TextureDescriptor {
     label: None,
     size: wgpu::Extent3d {
-      width: init.size.width,
-      height: init.size.height,
+      width: size.width,
+      height: size.height,
       depth_or_array_layers: 1,
     },
     mip_level_count: 1,

--- a/prototype/with_gif/Cargo.toml
+++ b/prototype/with_gif/Cargo.toml
@@ -10,7 +10,6 @@ cgmath      = "0.18.0"
 enum-rotate = "0.1.1"
 env_logger  = "0.11.5"
 wgpu        = "22.1.0"
-winit       = "0.30.5"
 wgsim       = { path = "../../lib/wgsim" }
 pollster    = "0.3.0"
 rand        = "0.8.5"


### PR DESCRIPTION
wgsimのAPIを改良する。

- `SurfaceConfigBuilder`を新規実装し、wgpuのSurfaceConfigurationをカスタマイズ可能に
- `WgpuContext`は`DrawingContext`に改名
- `DrawingContext`で`aspect_ratio()`メソッドを提供（縦横比の計算はよく使われるので）
- 独自の`Size`構造体を提供し、wgsim利用側ではwinitを依存に追加しなくて済むように
- `DrawingContext`で`resize()`メソッドを提供し、基本となるresize処理を毎回書かなくて済むように