### PR TITLE
コンピュートシェーダーで画像にガウシアンブラーをかけるサンプル

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image_gaussian_filter"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "env_logger",
+ "image",
+ "wgpu 22.1.0",
+ "wgsim",
+ "winit",
+]
+
+[[package]]
 name = "imgref"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3699,7 @@ dependencies = [
  "hello-glyphon",
  "image_average_filter",
  "image_blur",
+ "image_gaussian_filter",
  "instanced_cube_sphere_torus_base",
  "instanced_cube_sphere_torus_direction_light_1",
  "instanced_cube_sphere_torus_direction_light_2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ compute_mandelbrot_set                        = { path = "./tutorial/compute_man
 shader_step_rect                              = { path = "./shader_art/shader_step_rect" }
 image_blur                                    = { path = "./image_processing/image_blur" }
 image_average_filter                          = { path = "./image_processing/image_average_filter" }
+image_gaussian_filter                         = { path = "./image_processing/image_gaussian_filter" }
 rect-renderer                                 = { path = "./prototype/rect-renderer" }
 text-renderer                                 = { path = "./prototype/text-renderer" }
 with_gif                                      = { path = "./prototype/with_gif" }
@@ -60,6 +61,7 @@ members = [
   "shader_art/shader_step_rect",
   "image_processing/image_blur",
   "image_processing/image_average_filter",
+  "image_processing/image_gaussian_filter",
   "practice/cube_blinn_phong",
   "practice/rotate_cube_basic",
   "instanced_cube_sphere_torus/base",

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ cargo run -- image_processing/image_average_filter
 ```
 
 ```bash
+cargo run -- image_processing/image_gaussian_filter
+```
+
+```bash
 cargo run -- instanced_cube_sphere_torus/base
 ```
 

--- a/image_processing/image_average_filter/src/lib.rs
+++ b/image_processing/image_average_filter/src/lib.rs
@@ -36,7 +36,7 @@ fn setup() -> Initial {
     image,
     image_size,
     kernel_size: 3,
-    iterations: 2,
+    iterations: 1,
   }
 }
 

--- a/image_processing/image_gaussian_filter/Cargo.toml
+++ b/image_processing/image_gaussian_filter/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name    = "image_gaussian_filter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bytemuck   = "1.19.0"
+env_logger = "0.11.5"
+wgpu       = "22.1.0"
+wgsim      = { path = "../../lib/wgsim" }
+image      = "0.25.5"
+winit      = "0.30.5"

--- a/image_processing/image_gaussian_filter/src/blur.wgsl
+++ b/image_processing/image_gaussian_filter/src/blur.wgsl
@@ -1,0 +1,104 @@
+struct BlurParams {
+  kernel_size: u32,
+}
+
+// スレッド数
+const workgroup_size = 32u;
+
+// 各スレッドは、1つのタイル（複数のピクセル）を処理する
+const tile_size = 4u;
+
+// 1つのワークグループに必要なすべてのピクセルを保持する
+const cache_size = tile_size * workgroup_size; // 128
+
+// テクスチャルックアップ用のキャッシュ
+// 各スレッドは、ピクセルのタイルをワークグループの共有メモリに追加する
+var<workgroup> cache: array<array<vec3f, 128>, 4>;
+
+@group(0) @binding(0) var samp: sampler;
+@group(0) @binding(1) var<uniform> params: BlurParams;
+
+@group(1) @binding(0) var input_tex: texture_2d<f32>;
+@group(1) @binding(1) var output_tex: texture_storage_2d<rgba8unorm, write>;
+@group(1) @binding(2) var<uniform> flip_blur_dir: u32; // 0 or 1
+
+struct CsInput {
+  @builtin(workgroup_id) workgroup_id: vec3u,
+  @builtin(local_invocation_id) local_id: vec3u,
+  @builtin(global_invocation_id) global_id: vec3u
+}
+
+@compute @workgroup_size(32, 1, 1)
+fn cs_main(in: CsInput) {
+  let workgroup_id = in.workgroup_id.xy;
+  let local_id = in.local_id.xy;
+  
+  // テクスチャの寸法
+  let dims = vec2u(textureDimensions(input_tex, 0));
+  
+  let kernel_size = params.kernel_size;
+  
+  // キャッシュには、ディスパッチエリア内でカーネルを正しく評価するために必要な境界ピクセルも含める必要がある
+  let dispatch_size = vec2u(cache_size - (kernel_size - 1), 4u);
+  
+  // カーネルオフセット（カーネルの中心に隣接するピクセルの数）は、
+  // ピクセルキャッシュに含めるべき、ディスパッチエリア（=作業エリア）の
+  // 隣接する境界エリアを定義する
+  let kernel_offset = (kernel_size - 1) / 2;
+  
+  // このスレッドのタイルのローカルピクセルオフセット（ワークグループ内のタイル）
+  let tile_offset = local_id * vec2u(tile_size, 1u);
+  
+  // ワークグループのグローバルピクセルオフセット
+  let dispatch_offset = workgroup_id * dispatch_size;
+  
+  // カーネルの畳み込みに必要な境界ピクセルを含めるために、
+  // カーネルオフセットを引く（ディスパッチエリア内での処理のため）
+  let base_index = dispatch_offset + tile_offset - vec2u(kernel_offset, 0u);
+  
+  // このスレッドのタイルのピクセルをキャッシュに追加
+  for (var r = 0u; r < tile_size; r++) {
+    for (var c = 0u; c < tile_size; c++) {
+      var load_index = base_index + vec2u(c, r);
+      
+      if (flip_blur_dir != 0u) {
+        load_index = load_index.yx;
+      }
+      
+      let x = r;
+      let y = tile_size * local_id.x + c;
+      
+      // convert to uv space
+      let sample_coord: vec2f = vec2f(load_index) + vec2f(0.25);
+      let sample_uv: vec2f = sample_coord / vec2f(dims);
+      
+      let value = textureSampleLevel(input_tex, samp, sample_uv, 0.0).rgb;
+      cache[x][y] = value;
+    }
+  }
+
+  workgroupBarrier();
+  
+  for (var r = 0u; r < tile_size; r++) {
+    for (var c = 0u; c < tile_size; c++) {
+      var write_index = base_index + vec2u(c, r);
+      
+      if (flip_blur_dir != 0u) {
+        write_index = write_index.yx;
+      }
+    
+      let center = (tile_size * local_id.x) + c;
+    
+      if (center >= kernel_offset && center < cache_size - kernel_offset && all(write_index < dims)) {
+        // convolution with kernel
+        var acc = vec3(0.0);
+        for (var f = 0u; f < kernel_size; f++) {
+          let i = center + f - kernel_offset;
+          acc += (1.0 / f32(kernel_size)) * cache[r][i];
+        }
+        
+        textureStore(output_tex, write_index, vec4(acc, 1.0));
+      }
+    }
+  }
+}

--- a/image_processing/image_gaussian_filter/src/fullscreen-textured-quad.wgsl
+++ b/image_processing/image_gaussian_filter/src/fullscreen-textured-quad.wgsl
@@ -1,0 +1,60 @@
+@group(0) @binding(0) var screen_sampler: sampler;
+@group(0) @binding(1) var screen_texture: texture_2d<f32>;
+@group(0) @binding(2) var<uniform> resolution: vec2f;
+
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) frag_uv : vec2f,
+}
+
+fn object_fit_contain(pos: vec2f, aspect_ratio: f32) -> vec2f {
+  var scale: vec2<f32>;
+
+  if (aspect_ratio < 1.0) {
+    // テクスチャがスクリーンに比べて横長
+    scale = vec2<f32>(aspect_ratio, 1.0);
+  } else {
+    // テクスチャがスクリーンに比べて縦長または同じ比率
+    scale = vec2<f32>(1.0, 1.0 / aspect_ratio);
+  }
+  
+  return pos * scale;
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) i: u32) -> VertexOutput {
+  let tex_size = textureDimensions(screen_texture, 0);
+  
+  let tex_aspect = f32(tex_size.x) / f32(tex_size.y);
+  let screen_aspect = resolution.x / resolution.y;
+  
+  let aspect_ratio = tex_aspect / screen_aspect;
+  
+  var pos = array<vec2f, 6>(
+    object_fit_contain(vec2f( 1.0,  1.0), aspect_ratio),
+    object_fit_contain(vec2f( 1.0, -1.0), aspect_ratio),
+    object_fit_contain(vec2f(-1.0, -1.0), aspect_ratio),
+    object_fit_contain(vec2f( 1.0,  1.0), aspect_ratio),
+    object_fit_contain(vec2f(-1.0, -1.0), aspect_ratio),
+    object_fit_contain(vec2f(-1.0,  1.0), aspect_ratio),
+  );
+  
+  var uv = array<vec2f, 6>(
+    vec2f(1.0, 0.0),
+    vec2f(1.0, 1.0),
+    vec2f(0.0, 1.0),
+    vec2f(1.0, 0.0),
+    vec2f(0.0, 1.0),
+    vec2f(0.0, 0.0),
+  );
+  
+  var output: VertexOutput;
+  output.position = vec4(pos[i], 0.0, 1.0);
+  output.frag_uv = uv[i];
+  return output;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+  return textureSample(screen_texture, screen_sampler, in.frag_uv);
+}

--- a/image_processing/image_gaussian_filter/src/lib.rs
+++ b/image_processing/image_gaussian_filter/src/lib.rs
@@ -1,0 +1,526 @@
+use std::error::Error;
+
+use bytemuck::cast_slice;
+use image::GenericImageView;
+use wgpu::util::DeviceExt;
+use wgsim::app::App;
+use wgsim::ctx::{DrawingContext, Size};
+use wgsim::ppl::{ComputePipelineBuilder, RenderPipelineBuilder};
+use wgsim::render::{Render, RenderTarget};
+use wgsim::util;
+use winit::event::{ElementState, KeyEvent, WindowEvent};
+use winit::keyboard::{KeyCode, PhysicalKey};
+
+const TILE_SIZE: u32 = 4;
+const WORKGROUP_SIZE: u32 = 32;
+const CACHE_SIZE: u32 = TILE_SIZE * WORKGROUP_SIZE;
+
+const MIN_KERNEL_SIZE: u32 = 3;
+const MAX_KERNEL_SIZE: u32 = 33;
+const KERNEL_SIZE_STEP: u32 = 2;
+
+const MIN_ITERATIONS: u32 = 1;
+const MAX_ITERATIONS: u32 = 10;
+const ITERATIONS_STEP: u32 = 1;
+
+fn calc_dispatch_size(kernel_size: u32) -> u32 {
+  CACHE_SIZE - (kernel_size - 1)
+}
+
+fn setup() -> Initial {
+  let img_bytes = include_bytes!("../../../assets/img/stained-glass_w600.png");
+  let image = image::load_from_memory(img_bytes).unwrap();
+  let image_size = image.dimensions();
+
+  Initial {
+    image,
+    image_size,
+    kernel_size: 3,
+    iterations: 2,
+  }
+}
+
+pub fn run() -> Result<(), Box<dyn Error>> {
+  env_logger::init();
+
+  let initial = setup();
+
+  let mut app: App<State> = App::new("image_average_filter", initial);
+  app.run()?;
+
+  Ok(())
+}
+
+struct Initial {
+  image: image::DynamicImage,
+  image_size: (u32, u32),
+  kernel_size: u32,
+  iterations: u32,
+}
+
+struct State {
+  blur_pipeline: wgpu::ComputePipeline,
+  fullscreen_quad_pipeline: wgpu::RenderPipeline,
+
+  compute_constants_bind_group: wgpu::BindGroup,
+  compute_bind_group_for_tex_init: wgpu::BindGroup,
+  compute_bind_group_for_swap_1: wgpu::BindGroup,
+  compute_bind_group_for_swap_2: wgpu::BindGroup,
+  render_result_bind_group: wgpu::BindGroup,
+
+  blur_params_uniform_buffer: wgpu::Buffer,
+  resolution_uniform_buffer: wgpu::Buffer,
+
+  image_size: (u32, u32),
+  iterations: u32,
+
+  dispatch_size: u32,
+  kernel_size: u32,
+  kernel_size_updated: bool,
+
+  resolution_updated: bool,
+}
+
+impl<'a> Render<'a> for State {
+  type Initial = Initial;
+
+  async fn new(ctx: &DrawingContext<'a>, initial: &Self::Initial) -> Self {
+    //
+    // shader
+    //
+
+    let fullscreen_quad_shader = ctx.device.create_shader_module(
+      wgpu::include_wgsl!("./fullscreen-textured-quad.wgsl"),
+    );
+    let blur_shader =
+      ctx.device.create_shader_module(wgpu::include_wgsl!("./blur.wgsl"));
+
+    //
+    // texture & sampler
+    //
+
+    let sampler = ctx.device.create_sampler(&wgpu::SamplerDescriptor {
+      label: Some("sampler"),
+      mag_filter: wgpu::FilterMode::Linear,
+      min_filter: wgpu::FilterMode::Linear,
+      ..Default::default()
+    });
+
+    let image_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+      label: Some("image texture"),
+      size: wgpu::Extent3d {
+        width: initial.image_size.0,
+        height: initial.image_size.1,
+        depth_or_array_layers: 1,
+      },
+      mip_level_count: 1,
+      sample_count: 1,
+      dimension: wgpu::TextureDimension::D2,
+      format: wgpu::TextureFormat::Rgba8UnormSrgb, // 元画像の色味を保つため、ここだけsRGB
+      usage: wgpu::TextureUsages::COPY_DST
+        | wgpu::TextureUsages::RENDER_ATTACHMENT
+        | wgpu::TextureUsages::TEXTURE_BINDING,
+      view_formats: &[],
+    });
+    ctx.queue.write_texture(
+      image_texture.as_image_copy(),
+      &initial.image.to_rgba8(),
+      wgpu::ImageDataLayout {
+        offset: 0,
+        bytes_per_row: Some(4 * initial.image_size.0),
+        rows_per_image: Some(initial.image_size.1),
+      },
+      wgpu::Extent3d {
+        width: initial.image_size.0,
+        height: initial.image_size.1,
+        depth_or_array_layers: 1,
+      },
+    );
+
+    // for Ping-Pong pattern
+    let textures = (0..=1)
+      .map(|_| {
+        ctx.device.create_texture(&wgpu::TextureDescriptor {
+          label: Some("texture"),
+          size: wgpu::Extent3d {
+            width: initial.image_size.0,
+            height: initial.image_size.1,
+            depth_or_array_layers: 1,
+          },
+          mip_level_count: 1,
+          sample_count: 1,
+          dimension: wgpu::TextureDimension::D2,
+          format: wgpu::TextureFormat::Rgba8Unorm, // ここではsRGBは指定できないので注意（STORAGE_BINDINGとの併用不可）
+          usage: wgpu::TextureUsages::COPY_DST
+            | wgpu::TextureUsages::STORAGE_BINDING
+            | wgpu::TextureUsages::TEXTURE_BINDING,
+          view_formats: &[],
+        })
+      })
+      .collect::<Vec<_>>();
+
+    //
+    // uniform
+    //
+
+    // 横ブラーと縦ブラーの切り替え用
+    // 1つのバッファで管理し、切り替え時にバッファに書き込むよりも、最初から2つのバッファを用意しておいたほうが効率的
+    let flip_blur_dir_0_uniform_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("flip blur direction uniform buffer with 0"),
+        contents: cast_slice(&[0u32]),
+        usage: wgpu::BufferUsages::UNIFORM,
+      });
+    let flip_blur_dir_1_uniform_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("flip blur direction uniform buffer with 1"),
+        contents: cast_slice(&[1u32]),
+        usage: wgpu::BufferUsages::UNIFORM,
+      });
+
+    // 特定のキー入力イベントで更新する必要がある
+    let blur_params_uniform_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("blur params uniform buffer"),
+        contents: cast_slice(&[initial.kernel_size]),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+      });
+
+    // リサイズのたびに更新する必要がある
+    let resolution = ctx.resolution();
+    let resolution_uniform_buffer =
+      ctx.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("resolution uniform buffer"),
+        contents: cast_slice(&[
+          resolution.width as f32,
+          resolution.height as f32,
+        ]),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+      });
+
+    //
+    // bind group
+    //
+
+    // よく使うBindingTypeを定義しておく
+    let sampler_binding_type =
+      wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering);
+    let uniform_binding_type = wgpu::BindingType::Buffer {
+      ty: wgpu::BufferBindingType::Uniform,
+      has_dynamic_offset: false,
+      min_binding_size: None,
+    };
+    let texture_binding_type = wgpu::BindingType::Texture {
+      sample_type: wgpu::TextureSampleType::Float { filterable: true },
+      view_dimension: wgpu::TextureViewDimension::D2,
+      multisampled: false,
+    };
+    let texture_storage_binding_type = wgpu::BindingType::StorageTexture {
+      access: wgpu::StorageTextureAccess::WriteOnly,
+      format: wgpu::TextureFormat::Rgba8Unorm,
+      view_dimension: wgpu::TextureViewDimension::D2,
+    };
+
+    // 変更が必要ないものは1つのBindGroupにまとめる
+    let compute_constants_bind_group_layout = util::create_bind_group_layout(
+      &ctx.device,
+      &[sampler_binding_type, uniform_binding_type],
+      &[wgpu::ShaderStages::COMPUTE, wgpu::ShaderStages::COMPUTE],
+    );
+    let compute_constants_bind_group = util::create_bind_group(
+      &ctx.device,
+      &compute_constants_bind_group_layout,
+      &[
+        wgpu::BindingResource::Sampler(&sampler),
+        blur_params_uniform_buffer.as_entire_binding(),
+      ],
+    );
+
+    // スワップ用のBindGroupを複数用意するため、BindGroupLayoutを共通化
+    let compute_bind_group_layout = util::create_bind_group_layout(
+      &ctx.device,
+      &[
+        texture_binding_type,
+        texture_storage_binding_type,
+        uniform_binding_type,
+      ],
+      &[
+        wgpu::ShaderStages::COMPUTE,
+        wgpu::ShaderStages::COMPUTE,
+        wgpu::ShaderStages::COMPUTE,
+      ],
+    );
+
+    // 最初に画像テクスチャを読み込んで、Ping-Pongパターンの開始テクスチャにコピーする用
+    let compute_bind_group_for_tex_init = util::create_bind_group(
+      &ctx.device,
+      &compute_bind_group_layout,
+      &[
+        wgpu::BindingResource::TextureView(
+          &image_texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        wgpu::BindingResource::TextureView(
+          &textures[0].create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        flip_blur_dir_0_uniform_buffer.as_entire_binding(),
+      ],
+    );
+
+    // Ping-Pongパターンのスワップ用
+    let compute_bind_group_for_swap_1 = util::create_bind_group(
+      &ctx.device,
+      &compute_bind_group_layout,
+      &[
+        wgpu::BindingResource::TextureView(
+          &textures[0].create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        wgpu::BindingResource::TextureView(
+          &textures[1].create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        flip_blur_dir_1_uniform_buffer.as_entire_binding(),
+      ],
+    );
+    let compute_bind_group_for_swap_2 = util::create_bind_group(
+      &ctx.device,
+      &compute_bind_group_layout,
+      &[
+        wgpu::BindingResource::TextureView(
+          &textures[1].create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        wgpu::BindingResource::TextureView(
+          &textures[0].create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+        flip_blur_dir_0_uniform_buffer.as_entire_binding(),
+      ],
+    );
+
+    // 結果をスクリーンに描画するRenderPipeline用
+    let render_result_bind_group_layout = util::create_bind_group_layout(
+      &ctx.device,
+      &[
+        sampler_binding_type,
+        texture_binding_type,
+        uniform_binding_type,
+      ],
+      &[
+        wgpu::ShaderStages::FRAGMENT,
+        wgpu::ShaderStages::VERTEX_FRAGMENT,
+        wgpu::ShaderStages::VERTEX,
+      ],
+    );
+    let render_result_bind_group = util::create_bind_group(
+      &ctx.device,
+      &render_result_bind_group_layout,
+      &[
+        wgpu::BindingResource::Sampler(&sampler),
+        wgpu::BindingResource::TextureView(
+          &textures[1].create_view(&wgpu::TextureViewDescriptor::default()), // 最終結果はtextures[1]
+        ),
+        resolution_uniform_buffer.as_entire_binding(),
+      ],
+    );
+
+    //
+    // pipeline
+    //
+
+    let fullscreen_quad_pipeline_layout =
+      ctx.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Fullscreen Quad Pipeline Layout"),
+        bind_group_layouts: &[&render_result_bind_group_layout],
+        push_constant_ranges: &[],
+      });
+    let fullscreen_quad_pipeline = RenderPipelineBuilder::new(&ctx)
+      .vs_shader(&fullscreen_quad_shader, "vs_main")
+      .fs_shader(&fullscreen_quad_shader, "fs_main")
+      .pipeline_layout(&fullscreen_quad_pipeline_layout)
+      .build();
+
+    let blur_pipeline_layout =
+      ctx.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Blur Pipeline Layout"),
+        bind_group_layouts: &[
+          &compute_constants_bind_group_layout,
+          &compute_bind_group_layout,
+        ],
+        push_constant_ranges: &[],
+      });
+    let blur_pipeline = ComputePipelineBuilder::new(&ctx.device)
+      .cs_shader(&blur_shader, "cs_main")
+      .pipeline_layout(&blur_pipeline_layout)
+      .build();
+
+    Self {
+      blur_pipeline,
+      fullscreen_quad_pipeline,
+
+      compute_constants_bind_group,
+      compute_bind_group_for_tex_init,
+      compute_bind_group_for_swap_1,
+      compute_bind_group_for_swap_2,
+      render_result_bind_group,
+
+      blur_params_uniform_buffer,
+      resolution_uniform_buffer,
+
+      image_size: initial.image_size,
+      iterations: initial.iterations,
+
+      dispatch_size: calc_dispatch_size(initial.kernel_size),
+      kernel_size: initial.kernel_size,
+      kernel_size_updated: false,
+
+      resolution_updated: false,
+    }
+  }
+
+  fn resize(&mut self, ctx: &mut DrawingContext<'_>, size: Size) {
+    if size.width > 0 && size.height > 0 {
+      ctx.resize(size.into());
+      self.resolution_updated = true;
+    }
+  }
+
+  fn process_event(&mut self, event: &WindowEvent) -> bool {
+    match event {
+      WindowEvent::KeyboardInput {
+        event:
+          KeyEvent {
+            physical_key,
+            state: ElementState::Pressed,
+            ..
+          },
+        ..
+      } => match physical_key {
+        PhysicalKey::Code(KeyCode::KeyL) => {
+          self.kernel_size =
+            MAX_KERNEL_SIZE.min(self.kernel_size + KERNEL_SIZE_STEP);
+          println!("kernel size: {}", self.kernel_size);
+          self.kernel_size_updated = true;
+          true
+        }
+        PhysicalKey::Code(KeyCode::KeyJ) => {
+          self.kernel_size =
+            MIN_KERNEL_SIZE.max(self.kernel_size - KERNEL_SIZE_STEP);
+          println!("kernel size: {}", self.kernel_size);
+          self.kernel_size_updated = true;
+          true
+        }
+        PhysicalKey::Code(KeyCode::KeyO) => {
+          self.iterations =
+            MAX_ITERATIONS.min(self.iterations + ITERATIONS_STEP);
+          println!("iterations: {}", self.iterations);
+          true
+        }
+        PhysicalKey::Code(KeyCode::KeyU) => {
+          self.iterations =
+            MIN_ITERATIONS.max(self.iterations - ITERATIONS_STEP);
+          println!("iterations: {}", self.iterations);
+          true
+        }
+        _ => false,
+      },
+      _ => false,
+    }
+  }
+
+  fn update(&mut self, ctx: &DrawingContext, _dt: std::time::Duration) {
+    if self.kernel_size_updated {
+      self.dispatch_size = calc_dispatch_size(self.kernel_size);
+      ctx.queue.write_buffer(
+        &self.blur_params_uniform_buffer,
+        0,
+        cast_slice(&[self.kernel_size]),
+      );
+      self.kernel_size_updated = false;
+    }
+
+    if self.resolution_updated {
+      let resolution = ctx.resolution();
+      ctx.queue.write_buffer(
+        &self.resolution_uniform_buffer,
+        0,
+        cast_slice(&[resolution.width as f32, resolution.height as f32]),
+      );
+      self.resolution_updated = false;
+    }
+  }
+
+  fn draw(
+    &mut self,
+    encoder: &mut wgpu::CommandEncoder,
+    target: RenderTarget,
+    _sample_count: u32,
+  ) -> Result<Option<wgpu::SurfaceTexture>, wgpu::SurfaceError> {
+    let (view, frame) = match target {
+      RenderTarget::Surface(surface) => {
+        let frame = surface.get_current_texture()?;
+        let view =
+          frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (view, Some(frame))
+      }
+      RenderTarget::Texture(texture) => {
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (view, None)
+      }
+    };
+
+    let mut compute_pass =
+      encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+        label: Some("compute pass"),
+        ..Default::default()
+      });
+
+    compute_pass.set_pipeline(&self.blur_pipeline);
+    compute_pass.set_bind_group(0, &self.compute_constants_bind_group, &[]);
+
+    compute_pass.set_bind_group(1, &self.compute_bind_group_for_tex_init, &[]);
+    compute_pass.dispatch_workgroups(
+      self.image_size.0.div_ceil(self.dispatch_size),
+      self.image_size.1.div_ceil(TILE_SIZE),
+      1,
+    );
+
+    compute_pass.set_bind_group(1, &self.compute_bind_group_for_swap_1, &[]);
+    compute_pass.dispatch_workgroups(
+      self.image_size.1.div_ceil(self.dispatch_size),
+      self.image_size.0.div_ceil(TILE_SIZE),
+      1,
+    );
+
+    // tex_initとswap_1を1回目のiterationとして扱うため、1回減らす
+    for _ in 0..self.iterations - 1 {
+      compute_pass.set_bind_group(1, &self.compute_bind_group_for_swap_2, &[]);
+      compute_pass.dispatch_workgroups(
+        self.image_size.0.div_ceil(self.dispatch_size),
+        self.image_size.1.div_ceil(TILE_SIZE),
+        1,
+      );
+
+      compute_pass.set_bind_group(1, &self.compute_bind_group_for_swap_1, &[]);
+      compute_pass.dispatch_workgroups(
+        self.image_size.1.div_ceil(self.dispatch_size),
+        self.image_size.0.div_ceil(TILE_SIZE),
+        1,
+      );
+    }
+
+    drop(compute_pass);
+
+    let color_attachment = util::create_color_attachment(&view);
+    let mut render_pass =
+      encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("Render Pass"),
+        color_attachments: &[Some(color_attachment)],
+        ..Default::default()
+      });
+
+    render_pass.set_pipeline(&self.fullscreen_quad_pipeline);
+    render_pass.set_bind_group(0, &self.render_result_bind_group, &[]);
+    render_pass.draw(0..6, 0..1);
+
+    drop(render_pass);
+
+    Ok(frame)
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     "image_processing/image_blur" => Ok(image_blur::run()?),
     "image_processing/image_average_filter" => Ok(image_average_filter::run()?),
+    "image_processing/image_gaussian_filter" => {
+      Ok(image_gaussian_filter::run()?)
+    }
     "prototype/rect-renderer" => rect_renderer::run(),
     "prototype/text-renderer" => text_renderer::proto(),
     "prototype/with_gif" => Ok(with_gif::run("with_gif")?),


### PR DESCRIPTION
## 比較

### 平均値フィルタ

`iterations: 1, kernel_size: 13`

<img width="912" alt="kernel13-average" src="https://github.com/user-attachments/assets/998bcb79-dc43-4eee-9d83-5d2d32bad860">

### ガウシアンフィルタ

`iterations: 1, kernel_size: 13, sigma: 4`

<img width="912" alt="sigma4-kernel13-gaussian" src="https://github.com/user-attachments/assets/87f3ea18-65e3-469b-98b1-45c1e536d8fa">

## key-binding

- `D`: `sigma`を大きくする（`S`の右）
- `A`: `sigma`を小さくする（`S`の左）
- `L`: `kernel_size`を大きくする（`K`の右）
- `J`: `kernel_size`を小さくする（`K`の左）
- `O`: `iterations`を大きくする（`I`の右）
- `U`: `iterations`を小さくする（`I`の左）

## 参考

- https://3dcg-school.pro/unity-post-process-gaussian-blur/
- https://qiita.com/UWATechnology/items/9a92f3c1430d5fb5f280